### PR TITLE
Inherit params from parent kroutes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ var handle = function* (stack, next) {
 
     if (handler.match(this.path)) {
       // Alias the matched params onto the current request.
-      this.params = handler.params;
+      this.params = extend({}, this.params, handler.params);
 
       next = handler.fn.call(this, next);
     }


### PR DESCRIPTION
When nesting multiple kroute routers, the child routers are loosing this.params object from the parent:

`/user/:user_id/apps`
`kroute (/user/:user_id/apps) -> kroute (/)`

In this example it would make sense for `kroute(/)` to know the user_id param from it's parent router, but  this.params object is empty.
